### PR TITLE
don’t replace non-ascii characters

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -20,7 +20,7 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  **/
 
 'use strict';
@@ -138,18 +138,7 @@ function bundle(input, nc, options, complete) {
   })
 
   ws.on('close', function() {
-    var source = fs.readFileSync(bundlePath, 'utf8');
-    source = source.replace(/[^\x00-\x7F]/g, "");
-
-    // write the source modified to nexe.js
-    fs.writeFile(bundlePath, source, 'utf8', function(err) {
-      if (err) {
-        _log('error', 'failed to save source');
-        process.exit(1);
-      }
-
-      complete();
-    });
+    complete();
   });
 }
 


### PR DESCRIPTION
after digging a lot 😆 i've found that `nexe` is doing a very risky thing.. [non-ascii characters are begin replaced to empty strings](https://github.com/jsreport/nexe/blob/1.3.0/lib/bundle.js#L142), that change is causing the `yauzl` package (dependency of `jsreport-xlsx`) to not work correctly, `yauzl` is [using some non-ascii characters in its source code to handle some things](https://github.com/thejoshwolfe/yauzl/blob/2.6.0/index.js#L643) and when it is getting bundled all those characters are being replaced by empty strings. this is the same problem that you've faced before [here](https://github.com/pofider/msexcel-builder/commit/d6e136aada6bbb48b20ba5125bd89d83b3d0a18a) (browserify is handling this characters correctly, `nexe` was the problem) and even [other people](https://github.com/nexe/nexe/issues/206).

Seems like compiling non-ascii source code with older versions of node was not working, so they opted for replacing those characters as a workaround, but for our case it doesn't matter and we can remove that part without problems. (even in future versions of `nexe`, [they are not using this code anymore](https://github.com/nexe/nexe/blob/v2.0.0/lib/package.js#L74))

with this PR all samples from `jsreport-sample-template` are working in normal jsreport installation, jsreport.js bundle and jsreport.exe. 🎉 
